### PR TITLE
deps: Support Next.js 14 / 15 as peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "packageManager": "pnpm@9.9.0+sha512.60c18acd138bff695d339be6ad13f7e936eea6745660d4cc4a776d5247c540d0edee1a563695c183a66eb917ef88f2b4feb1fc25f32a7adcadc7aaf3438e99c1",
   "peerDependencies": {
-    "next": "^14.2.11",
+    "next": "^14 || ^15",
     "react": "^18.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Address https://github.com/LayerXcom/next-navigation-guard/issues/5