### PR TITLE
fix: Jest import

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    "import": "./dist/index.js"
+    "import": "./dist/index.js",
+    "require": "./dist/index.js"
   },
   "files": [
     "dist"


### PR DESCRIPTION
I need this for jest.

There is a problem, when jest can not find modules without it.
https://stackoverflow.com/a/75595580/612011

I am getting.

```
 FAIL  src/routes/LeagueFinder/LeagueFinder.test.tsx
  ● Test suite failed to run

    Cannot find module 'next-navigation-guard' from '
```