### PR TITLE
fix: newToken work under http

### DIFF
--- a/src/utils/historyAugmentation.tsx
+++ b/src/utils/historyAugmentation.tsx
@@ -7,7 +7,15 @@ let setupDone = false;
 let writeState = () => {};
 
 export function newToken() {
-  return crypto.randomUUID().substring(0, 8);
+  const length = 8;
+
+  // crypto.randomUUID is available only in secure contexts (HTTPS)
+  return crypto.randomUUID
+    ? crypto.randomUUID().substring(0, length)
+    : Math.random()
+        .toString(36)
+        .substring(2, length + 2)
+        .padEnd(length, "0");
 }
 
 // Next.js also modifies history.pushState and history.replaceState in useEffect.

--- a/src/utils/historyAugmentation.tsx
+++ b/src/utils/historyAugmentation.tsx
@@ -7,15 +7,7 @@ let setupDone = false;
 let writeState = () => {};
 
 export function newToken() {
-  const length = 8;
-
-  // crypto.randomUUID is available only in secure contexts (HTTPS)
-  return crypto.randomUUID
-    ? crypto.randomUUID().substring(0, length)
-    : Math.random()
-        .toString(36)
-        .substring(2, length + 2)
-        .padEnd(length, "0");
+  return Math.random().toString(36).substring(2);
 }
 
 // Next.js also modifies history.pushState and history.replaceState in useEffect.


### PR DESCRIPTION
#12

During development, there are cases where next.js is accessed over HTTP. 
Since browsers cannot use `crypto.randomUUID()` with HTTP connection, it should fallback to other methods of random number generation, such as `Math.random()`.

https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID
