### PR TITLE
Export NavigationGuardProviderContext

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { useNavigationGuard } from "./hooks/useNavigationGuard";
 export { NavigationGuardProvider } from "./components/NavigationGuardProvider";
+export { NavigationGuardProviderContext } from "./components/NavigationGuardProviderContext";
 export type { NavigationGuardCallback as NavigationGuard } from "./types";


### PR DESCRIPTION
This allows users of this library to hook into the guardMapRef value and build their own custom functionality on top of it.