### PR TITLE
fix: guard against null history.state in createHandlePopState

### DIFF
--- a/src/hooks/useInterceptPopState.ts
+++ b/src/hooks/useInterceptPopState.ts
@@ -59,8 +59,7 @@ function createHandlePopState(
 ) {
   let dispatchedState: unknown;
 
-  return (rawNextState: any): boolean => {
-    const nextState = rawNextState ?? {};
+  return (nextState: any = {}): boolean => {
     const token: string | undefined = nextState.__next_navigation_guard_token;
     const nextIndex: number =
       Number(nextState.__next_navigation_guard_stack_index) || 0;

--- a/src/hooks/useInterceptPopState.ts
+++ b/src/hooks/useInterceptPopState.ts
@@ -59,7 +59,8 @@ function createHandlePopState(
 ) {
   let dispatchedState: unknown;
 
-  return (nextState: any): boolean => {
+  return (rawNextState: any): boolean => {
+    const nextState = rawNextState ?? {};
     const token: string | undefined = nextState.__next_navigation_guard_token;
     const nextIndex: number =
       Number(nextState.__next_navigation_guard_stack_index) || 0;


### PR DESCRIPTION
This PR prevents a runtime error in `useInterceptPopState` when navigating to the same page with a different hash (or anytime `history.state` may be null)

Fixes: #10 