### PR TITLE
Move disableForTesting to NavigationGuardProvider; add mockConfirm

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,12 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.0] - 2026-02-26
+## [0.3.0] - 2026-04-28
 
 ### Added
 
-- Add `disableForTesting` option to `useNavigationGuard` to make the hook a complete no-op without requiring `NavigationGuardProvider` context, intended for test and storybook environments.
-- Support Next.js 16 as peer dependency and add E2E CI targets for v16.0 and v16.1.
+- Add `disableForTesting` prop to `NavigationGuardProvider`. When set, the library installs none of its host-environment hooks (no `popstate` / `beforeunload` / `click` listeners, no `window.history` augmentation, no Next.js router context overrides). `useNavigationGuard` keeps registering and `enabled` / `confirm` / `active` / `accept` / `reject` keep behaving as usual, so component-level tests and storybook stories render without mocking `window` or Next.js internals.
+- Support Next.js 16 as peer dependency and add E2E CI targets for v16.0, v16.1, and v16.2.
+
+### Fixed
+
+- Guard against null `history.state` in `createHandlePopState` ([#48](https://github.com/LayerXcom/next-navigation-guard/pull/48)). @sethcarlton
+- Fix import types ([#38](https://github.com/LayerXcom/next-navigation-guard/pull/38)). @lluiscab
 
 ## [0.2.0] - 2025-06-28
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `disableForTesting` prop to `NavigationGuardProvider`. When set, the library installs none of its host-environment hooks (no `popstate` / `beforeunload` / `click` listeners, no `window.history` augmentation, no Next.js router context overrides). `useNavigationGuard` keeps registering and `enabled` / `confirm` / `active` / `accept` / `reject` keep behaving as usual, so component-level tests and storybook stories render without mocking `window` or Next.js internals.
+- Add `disableForTesting` prop to `NavigationGuardProvider`. When set, the library skips its host-environment hooks (no `popstate` / `beforeunload` / `click` listeners, no `window.history` augmentation), but still overrides Next.js's App Router and Pages Router contexts so navigation through Next.js routers (including mock routers in tests) keeps evaluating registered guards. `useNavigationGuard` continues to register normally so `enabled` / `confirm` / `active` / `accept` / `reject` work as in production. Pass `{ mockConfirm }` to additionally replace every guard's `confirm` during evaluation, useful for asserting on navigation attempts without rendering the confirmation UI.
 - Support Next.js 16 as peer dependency and add E2E CI targets for v16.0, v16.1, and v16.2.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -77,12 +77,26 @@ See working example in example/ directory and its `NavigationGuardToggle` compon
 
 ## Testing / Storybook
 
-Pass `disableForTesting` to `NavigationGuardProvider` so the library does not install any of its host-environment hooks (no `popstate` / `beforeunload` / `click` listeners, no `window.history` augmentation, no Next.js router context overrides). `useNavigationGuard` keeps registering normally, so the `enabled` predicate, the `confirm` callback, and the `active` / `accept` / `reject` returned by the hook all keep working — your component renders the same as in production without needing mocks for `window` or Next.js.
+Pass `disableForTesting` to `NavigationGuardProvider` and the library will skip its host-environment hooks (no `popstate` / `beforeunload` / `click` listeners, no `window.history` augmentation). The App Router / Pages Router context overrides remain in place, so navigation through Next.js routers (incl. mock routers in tests) still evaluates registered guards. `useNavigationGuard` keeps registering normally, so the `enabled` predicate, the `confirm` callback, and `active` / `accept` / `reject` work as in production.
 
 ```tsx
+// each guard's own confirm runs as in production
 render(
   <NavigationGuardProvider disableForTesting>
     <MyComponent />
   </NavigationGuardProvider>
 );
+```
+
+To bypass the confirmation UI entirely in tests (and assert which navigations were attempted), pass `mockConfirm`. It replaces every registered guard's `confirm` during evaluation; per-guard `enabled` predicates still run.
+
+```tsx
+const mockConfirm = jest.fn().mockResolvedValue(true);
+render(
+  <NavigationGuardProvider disableForTesting={{ mockConfirm }}>
+    <MyComponent />
+  </NavigationGuardProvider>
+);
+// drive navigation through your mock router…
+expect(mockConfirm).toHaveBeenCalledWith({ to: "/foo", type: "push" });
 ```

--- a/README.md
+++ b/README.md
@@ -74,3 +74,15 @@ pnpm install next-navigation-guard
   ```
 
 See working example in example/ directory and its `NavigationGuardToggle` component.
+
+## Testing / Storybook
+
+Pass `disableForTesting` to `NavigationGuardProvider` so the library does not install any of its host-environment hooks (no `popstate` / `beforeunload` / `click` listeners, no `window.history` augmentation, no Next.js router context overrides). `useNavigationGuard` keeps registering normally, so the `enabled` predicate, the `confirm` callback, and the `active` / `accept` / `reject` returned by the hook all keep working — your component renders the same as in production without needing mocks for `window` or Next.js.
+
+```tsx
+render(
+  <NavigationGuardProvider disableForTesting>
+    <MyComponent />
+  </NavigationGuardProvider>
+);
+```

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@playwright/test": "^1.52.0",
     "@types/node": "^20",
     "@types/react": "^18.3.5",
-    "next": "^14.2.11",
+    "next": "^14.2.35",
     "playwright": "^1.52.0",
     "react": "^18.3.1",
     "tsup": "^8.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^18.3.5
         version: 18.3.5
       next:
-        specifier: ^14.2.11
-        version: 14.2.11(@playwright/test@1.52.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^14.2.35
+        version: 14.2.35(@playwright/test@1.52.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       playwright:
         specifier: ^1.52.0
         version: 1.52.0
@@ -232,8 +232,8 @@ packages:
   '@next/env@14.2.0':
     resolution: {integrity: sha512-4+70ELtSbRtYUuyRpAJmKC8NHBW2x1HMje9KO2Xd7IkoyucmV9SjgO+qeWMC0JWkRQXgydv1O7yKOK8nu/rITQ==}
 
-  '@next/env@14.2.11':
-    resolution: {integrity: sha512-HYsQRSIXwiNqvzzYThrBwq6RhXo3E0n8j8nQnAs8i4fCEo2Zf/3eS0IiRA8XnRg9Ha0YnpkyJZIZg1qEwemrHw==}
+  '@next/env@14.2.35':
+    resolution: {integrity: sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==}
 
   '@next/swc-darwin-arm64@14.2.0':
     resolution: {integrity: sha512-kHktLlw0AceuDnkVljJ/4lTJagLzDiO3klR1Fzl2APDFZ8r+aTxNaNcPmpp0xLMkgRwwk6sggYeqq0Rz9K4zzA==}
@@ -241,8 +241,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-arm64@14.2.11':
-    resolution: {integrity: sha512-eiY9u7wEJZWp/Pga07Qy3ZmNEfALmmSS1HtsJF3y1QEyaExu7boENz11fWqDmZ3uvcyAxCMhTrA1jfVxITQW8g==}
+  '@next/swc-darwin-arm64@14.2.33':
+    resolution: {integrity: sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -253,8 +253,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@14.2.11':
-    resolution: {integrity: sha512-lnB0zYCld4yE0IX3ANrVMmtAbziBb7MYekcmR6iE9bujmgERl6+FK+b0MBq0pl304lYe7zO4yxJus9H/Af8jbg==}
+  '@next/swc-darwin-x64@14.2.33':
+    resolution: {integrity: sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -265,8 +265,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-gnu@14.2.11':
-    resolution: {integrity: sha512-Ulo9TZVocYmUAtzvZ7FfldtwUoQY0+9z3BiXZCLSUwU2bp7GqHA7/bqrfsArDlUb2xeGwn3ZuBbKtNK8TR0A8w==}
+  '@next/swc-linux-arm64-gnu@14.2.33':
+    resolution: {integrity: sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -277,8 +277,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@14.2.11':
-    resolution: {integrity: sha512-fH377DnKGyUnkWlmUpFF1T90m0dADBfK11dF8sOQkiELF9M+YwDRCGe8ZyDzvQcUd20Rr5U7vpZRrAxKwd3Rzg==}
+  '@next/swc-linux-arm64-musl@14.2.33':
+    resolution: {integrity: sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -289,8 +289,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@14.2.11':
-    resolution: {integrity: sha512-a0TH4ZZp4NS0LgXP/488kgvWelNpwfgGTUCDXVhPGH6pInb7yIYNgM4kmNWOxBFt+TIuOH6Pi9NnGG4XWFUyXQ==}
+  '@next/swc-linux-x64-gnu@14.2.33':
+    resolution: {integrity: sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -301,8 +301,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@14.2.11':
-    resolution: {integrity: sha512-DYYZcO4Uir2gZxA4D2JcOAKVs8ZxbOFYPpXSVIgeoQbREbeEHxysVsg3nY4FrQy51e5opxt5mOHl/LzIyZBoKA==}
+  '@next/swc-linux-x64-musl@14.2.33':
+    resolution: {integrity: sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -313,8 +313,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-arm64-msvc@14.2.11':
-    resolution: {integrity: sha512-PwqHeKG3/kKfPpM6of1B9UJ+Er6ySUy59PeFu0Un0LBzJTRKKAg2V6J60Yqzp99m55mLa+YTbU6xj61ImTv9mg==}
+  '@next/swc-win32-arm64-msvc@14.2.33':
+    resolution: {integrity: sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -325,8 +325,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@next/swc-win32-ia32-msvc@14.2.11':
-    resolution: {integrity: sha512-0U7PWMnOYIvM74GY6rbH6w7v+vNPDVH1gUhlwHpfInJnNe5LkmUZqhp7FNWeNa5wbVgRcRi1F1cyxp4dmeLLvA==}
+  '@next/swc-win32-ia32-msvc@14.2.33':
+    resolution: {integrity: sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
@@ -337,8 +337,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@14.2.11':
-    resolution: {integrity: sha512-gQpS7mcgovWoaTG1FbS5/ojF7CGfql1Q0ZLsMrhcsi2Sr9HEqsUZ70MPJyaYBXbk6iEAP7UXMD9HC8KY1qNwvA==}
+  '@next/swc-win32-x64-msvc@14.2.33':
+    resolution: {integrity: sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -745,8 +745,8 @@ packages:
       sass:
         optional: true
 
-  next@14.2.11:
-    resolution: {integrity: sha512-8MDFqHBhdmR2wdfaWc8+lW3A/hppFe1ggQ9vgIu/g2/2QEMYJrPoQP6b+VNk56gIug/bStysAmrpUKtj3XN8Bw==}
+  next@14.2.35:
+    resolution: {integrity: sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==}
     engines: {node: '>=18.17.0'}
     hasBin: true
     peerDependencies:
@@ -1117,60 +1117,60 @@ snapshots:
 
   '@next/env@14.2.0': {}
 
-  '@next/env@14.2.11': {}
+  '@next/env@14.2.35': {}
 
   '@next/swc-darwin-arm64@14.2.0':
     optional: true
 
-  '@next/swc-darwin-arm64@14.2.11':
+  '@next/swc-darwin-arm64@14.2.33':
     optional: true
 
   '@next/swc-darwin-x64@14.2.0':
     optional: true
 
-  '@next/swc-darwin-x64@14.2.11':
+  '@next/swc-darwin-x64@14.2.33':
     optional: true
 
   '@next/swc-linux-arm64-gnu@14.2.0':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@14.2.11':
+  '@next/swc-linux-arm64-gnu@14.2.33':
     optional: true
 
   '@next/swc-linux-arm64-musl@14.2.0':
     optional: true
 
-  '@next/swc-linux-arm64-musl@14.2.11':
+  '@next/swc-linux-arm64-musl@14.2.33':
     optional: true
 
   '@next/swc-linux-x64-gnu@14.2.0':
     optional: true
 
-  '@next/swc-linux-x64-gnu@14.2.11':
+  '@next/swc-linux-x64-gnu@14.2.33':
     optional: true
 
   '@next/swc-linux-x64-musl@14.2.0':
     optional: true
 
-  '@next/swc-linux-x64-musl@14.2.11':
+  '@next/swc-linux-x64-musl@14.2.33':
     optional: true
 
   '@next/swc-win32-arm64-msvc@14.2.0':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@14.2.11':
+  '@next/swc-win32-arm64-msvc@14.2.33':
     optional: true
 
   '@next/swc-win32-ia32-msvc@14.2.0':
     optional: true
 
-  '@next/swc-win32-ia32-msvc@14.2.11':
+  '@next/swc-win32-ia32-msvc@14.2.33':
     optional: true
 
   '@next/swc-win32-x64-msvc@14.2.0':
     optional: true
 
-  '@next/swc-win32-x64-msvc@14.2.11':
+  '@next/swc-win32-x64-msvc@14.2.33':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -1545,9 +1545,9 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@14.2.11(@playwright/test@1.52.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.35(@playwright/test@1.52.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@next/env': 14.2.11
+      '@next/env': 14.2.35
       '@swc/helpers': 0.5.5
       busboy: 1.6.0
       caniuse-lite: 1.0.30001660
@@ -1557,15 +1557,15 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       styled-jsx: 5.1.1(react@18.3.1)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 14.2.11
-      '@next/swc-darwin-x64': 14.2.11
-      '@next/swc-linux-arm64-gnu': 14.2.11
-      '@next/swc-linux-arm64-musl': 14.2.11
-      '@next/swc-linux-x64-gnu': 14.2.11
-      '@next/swc-linux-x64-musl': 14.2.11
-      '@next/swc-win32-arm64-msvc': 14.2.11
-      '@next/swc-win32-ia32-msvc': 14.2.11
-      '@next/swc-win32-x64-msvc': 14.2.11
+      '@next/swc-darwin-arm64': 14.2.33
+      '@next/swc-darwin-x64': 14.2.33
+      '@next/swc-linux-arm64-gnu': 14.2.33
+      '@next/swc-linux-arm64-musl': 14.2.33
+      '@next/swc-linux-x64-gnu': 14.2.33
+      '@next/swc-linux-x64-musl': 14.2.33
+      '@next/swc-win32-arm64-msvc': 14.2.33
+      '@next/swc-win32-ia32-msvc': 14.2.33
+      '@next/swc-win32-x64-msvc': 14.2.33
       '@playwright/test': 1.52.0
     transitivePeerDependencies:
       - '@babel/core'

--- a/src/components/InterceptAppRouterProvider.tsx
+++ b/src/components/InterceptAppRouterProvider.tsx
@@ -3,16 +3,21 @@
 import { AppRouterContext } from "next/dist/shared/lib/app-router-context.shared-runtime";
 import React, { MutableRefObject } from "react";
 import { useInterceptedAppRouter } from "../hooks/useInterceptedAppRouter";
-import { GuardDef } from "../types";
+import { GuardDef, NavigationGuardCallback } from "../types";
 
 export function InterceptAppRouterProvider({
   guardMapRef,
+  mockConfirmRef,
   children,
 }: {
   guardMapRef: MutableRefObject<Map<string, GuardDef>>;
+  mockConfirmRef: MutableRefObject<NavigationGuardCallback | undefined>;
   children: React.ReactNode;
 }) {
-  const interceptedRouter = useInterceptedAppRouter({ guardMapRef });
+  const interceptedRouter = useInterceptedAppRouter({
+    guardMapRef,
+    mockConfirmRef,
+  });
   if (!interceptedRouter) {
     return <>{children}</>;
   }

--- a/src/components/InterceptPagesRouterProvider.tsx
+++ b/src/components/InterceptPagesRouterProvider.tsx
@@ -3,7 +3,7 @@
 import { RouterContext } from "next/dist/shared/lib/router-context.shared-runtime";
 import React, { MutableRefObject } from "react";
 import { useInterceptedPagesRouter } from "../hooks/useInterceptedPagesRouter";
-import { GuardDef, NavigationGuardCallback } from "../types";
+import { GuardDef } from "../types";
 
 export function InterceptPagesRouterProvider({
   guardMapRef,

--- a/src/components/InterceptPagesRouterProvider.tsx
+++ b/src/components/InterceptPagesRouterProvider.tsx
@@ -3,16 +3,21 @@
 import { RouterContext } from "next/dist/shared/lib/router-context.shared-runtime";
 import React, { MutableRefObject } from "react";
 import { useInterceptedPagesRouter } from "../hooks/useInterceptedPagesRouter";
-import { GuardDef } from "../types";
+import { GuardDef, NavigationGuardCallback } from "../types";
 
 export function InterceptPagesRouterProvider({
   guardMapRef,
+  mockConfirmRef,
   children,
 }: {
   guardMapRef: MutableRefObject<Map<string, GuardDef>>;
+  mockConfirmRef: MutableRefObject<NavigationGuardCallback | undefined>;
   children: React.ReactNode;
 }) {
-  const interceptedRouter = useInterceptedPagesRouter({ guardMapRef });
+  const interceptedRouter = useInterceptedPagesRouter({
+    guardMapRef,
+    mockConfirmRef,
+  });
   if (!interceptedRouter) {
     return <>{children}</>;
   }

--- a/src/components/NavigationGuardProvider.tsx
+++ b/src/components/NavigationGuardProvider.tsx
@@ -1,13 +1,34 @@
 "use client";
 
-import React, { useRef } from "react";
+import React, { useMemo, useRef } from "react";
 import { useInterceptPageUnload } from "../hooks/useInterceptPageUnload";
 import { useInterceptPopState } from "../hooks/useInterceptPopState";
 import { useInterceptLinkClicks } from "../hooks/useInterceptLinkClicks";
-import { DisableForTesting, GuardDef } from "../types";
+import { useIsomorphicLayoutEffect } from "../hooks/useIsomorphicLayoutEffect";
+import {
+  DisableForTesting,
+  GuardDef,
+  NavigationGuardCallback,
+} from "../types";
 import { InterceptAppRouterProvider } from "./InterceptAppRouterProvider";
 import { InterceptPagesRouterProvider } from "./InterceptPagesRouterProvider";
-import { NavigationGuardProviderContext } from "./NavigationGuardProviderContext";
+import {
+  NavigationGuardContextValue,
+  NavigationGuardProviderContext,
+} from "./NavigationGuardProviderContext";
+
+function resolveMockConfirm(
+  disableForTesting: DisableForTesting | undefined
+): NavigationGuardCallback | undefined {
+  if (
+    disableForTesting &&
+    typeof disableForTesting === "object" &&
+    "mockConfirm" in disableForTesting
+  ) {
+    return disableForTesting.mockConfirm;
+  }
+  return undefined;
+}
 
 export function NavigationGuardProvider({
   children,
@@ -15,32 +36,47 @@ export function NavigationGuardProvider({
 }: {
   children: React.ReactNode;
   /**
-   * Disables every library-side bridge into the host environment (popstate /
-   * beforeunload / click listeners, history augmentation, Next.js router
-   * context overrides). `useNavigationGuard` continues to register and runs
-   * `enabled` / `confirm` / `active` / `accept` / `reject` as usual.
-   * See {@link DisableForTesting} for the full contract.
+   * Disables host-environment hooks (popstate / beforeunload / click listeners
+   * and `window.history` augmentation). Router context overrides remain in
+   * place so navigation through Next.js routers still hits guards. Pass
+   * `{ mockConfirm }` to additionally replace every guard's `confirm` during
+   * evaluation. See {@link DisableForTesting} for the full contract.
    */
   disableForTesting?: DisableForTesting;
 }) {
   const guardMapRef = useRef(new Map<string, GuardDef>());
   const disabled = !!disableForTesting;
 
-  useInterceptPopState({ guardMapRef, disabled });
+  const mockConfirm = resolveMockConfirm(disableForTesting);
+  const mockConfirmRef = useRef<NavigationGuardCallback | undefined>(
+    mockConfirm
+  );
+  useIsomorphicLayoutEffect(() => {
+    mockConfirmRef.current = mockConfirm;
+  }, [mockConfirm]);
+
+  useInterceptPopState({ guardMapRef, mockConfirmRef, disabled });
   useInterceptPageUnload({ guardMapRef, disabled });
   useInterceptLinkClicks({ guardMapRef, disabled });
 
+  const contextValue = useMemo<NavigationGuardContextValue>(
+    () => ({ guardMapRef, mockConfirmRef }),
+    []
+  );
+
   return (
-    <NavigationGuardProviderContext.Provider value={guardMapRef}>
-      {disabled ? (
-        children
-      ) : (
-        <InterceptAppRouterProvider guardMapRef={guardMapRef}>
-          <InterceptPagesRouterProvider guardMapRef={guardMapRef}>
-            {children}
-          </InterceptPagesRouterProvider>
-        </InterceptAppRouterProvider>
-      )}
+    <NavigationGuardProviderContext.Provider value={contextValue}>
+      <InterceptAppRouterProvider
+        guardMapRef={guardMapRef}
+        mockConfirmRef={mockConfirmRef}
+      >
+        <InterceptPagesRouterProvider
+          guardMapRef={guardMapRef}
+          mockConfirmRef={mockConfirmRef}
+        >
+          {children}
+        </InterceptPagesRouterProvider>
+      </InterceptAppRouterProvider>
     </NavigationGuardProviderContext.Provider>
   );
 }

--- a/src/components/NavigationGuardProvider.tsx
+++ b/src/components/NavigationGuardProvider.tsx
@@ -4,29 +4,43 @@ import React, { useRef } from "react";
 import { useInterceptPageUnload } from "../hooks/useInterceptPageUnload";
 import { useInterceptPopState } from "../hooks/useInterceptPopState";
 import { useInterceptLinkClicks } from "../hooks/useInterceptLinkClicks";
-import { GuardDef } from "../types";
+import { DisableForTesting, GuardDef } from "../types";
 import { InterceptAppRouterProvider } from "./InterceptAppRouterProvider";
 import { InterceptPagesRouterProvider } from "./InterceptPagesRouterProvider";
 import { NavigationGuardProviderContext } from "./NavigationGuardProviderContext";
 
 export function NavigationGuardProvider({
   children,
+  disableForTesting,
 }: {
   children: React.ReactNode;
+  /**
+   * Disables every library-side bridge into the host environment (popstate /
+   * beforeunload / click listeners, history augmentation, Next.js router
+   * context overrides). `useNavigationGuard` continues to register and runs
+   * `enabled` / `confirm` / `active` / `accept` / `reject` as usual.
+   * See {@link DisableForTesting} for the full contract.
+   */
+  disableForTesting?: DisableForTesting;
 }) {
   const guardMapRef = useRef(new Map<string, GuardDef>());
+  const disabled = !!disableForTesting;
 
-  useInterceptPopState({ guardMapRef });
-  useInterceptPageUnload({ guardMapRef });
-  useInterceptLinkClicks({ guardMapRef });
+  useInterceptPopState({ guardMapRef, disabled });
+  useInterceptPageUnload({ guardMapRef, disabled });
+  useInterceptLinkClicks({ guardMapRef, disabled });
 
   return (
     <NavigationGuardProviderContext.Provider value={guardMapRef}>
-      <InterceptAppRouterProvider guardMapRef={guardMapRef}>
-        <InterceptPagesRouterProvider guardMapRef={guardMapRef}>
-          {children}
-        </InterceptPagesRouterProvider>
-      </InterceptAppRouterProvider>
+      {disabled ? (
+        children
+      ) : (
+        <InterceptAppRouterProvider guardMapRef={guardMapRef}>
+          <InterceptPagesRouterProvider guardMapRef={guardMapRef}>
+            {children}
+          </InterceptPagesRouterProvider>
+        </InterceptAppRouterProvider>
+      )}
     </NavigationGuardProviderContext.Provider>
   );
 }

--- a/src/components/NavigationGuardProviderContext.tsx
+++ b/src/components/NavigationGuardProviderContext.tsx
@@ -1,9 +1,14 @@
 "use client";
 
 import React, { MutableRefObject } from "react";
-import { GuardDef } from "../types";
+import { GuardDef, NavigationGuardCallback } from "../types";
+
+export interface NavigationGuardContextValue {
+  guardMapRef: MutableRefObject<Map<string, GuardDef>>;
+  mockConfirmRef: MutableRefObject<NavigationGuardCallback | undefined>;
+}
 
 export const NavigationGuardProviderContext = React.createContext<
-  MutableRefObject<Map<string, GuardDef>> | undefined
+  NavigationGuardContextValue | undefined
 >(undefined);
 NavigationGuardProviderContext.displayName = "NavigationGuardProviderContext";

--- a/src/hooks/useInterceptLinkClicks.ts
+++ b/src/hooks/useInterceptLinkClicks.ts
@@ -14,30 +14,33 @@ try {
 
 export function useInterceptLinkClicks({
   guardMapRef,
+  disabled,
 }: {
   guardMapRef: MutableRefObject<Map<string, GuardDef>>;
+  disabled: boolean;
 }) {
   const isSetup = useRef(false);
   const needsInterceptor = useRef<boolean | null>(null);
   const appRouter = AppRouterContext ? useContext(AppRouterContext) : null;
 
   useIsomorphicLayoutEffect(() => {
+    if (disabled) return;
     if (typeof window === 'undefined' || isSetup.current) return;
     isSetup.current = true;
-    
+
     // If AppRouterContext doesn't exist (old Next.js), skip
     if (!AppRouterContext) {
       debug('AppRouterContext not available, skipping link interceptor');
       return;
     }
-    
+
     // Only use link interceptor if we're in App Router mode
     // In Pages Router, the router context interception works fine
     if (!appRouter) {
       debug('Not in App Router context, skipping link interceptor');
       return;
     }
-    
+
     // Dynamically check if we need the interceptor
     // This is done by testing if our router.push interceptor is working
     if (needsInterceptor.current === null) {
@@ -45,14 +48,14 @@ export function useInterceptLinkClicks({
       if (appRouter && typeof (appRouter as any).push === 'function') {
         (appRouter as any)._guardIntercepted = true;
       }
-      
+
       // After a short delay, check if clicking links uses our intercepted router
       setTimeout(() => {
         needsInterceptor.current = true; // Default to true for Next.js 15.3+
         debug('Link click interceptor enabled for Next.js 15.3+ compatibility');
       }, 100);
     }
-    
+
     if (needsInterceptor.current === false) {
       debug('Link click interceptor not needed');
       return;
@@ -64,70 +67,70 @@ export function useInterceptLinkClicks({
     const handleLinkClick = async (e: MouseEvent) => {
       const target = e.target as HTMLElement;
       const link = target.closest('a[href]') as HTMLAnchorElement;
-      
+
       if (!link) return;
-      
+
       // Skip if already being processed
       if (link.dataset.guardProcessing === 'true') return;
-      
+
       const href = link.getAttribute('href');
       if (!href) return;
-      
+
       // Skip external links
       if (href.startsWith('http://') || href.startsWith('https://') || href.startsWith('//')) {
         return;
       }
-      
+
       // Skip hash links
       if (href.startsWith('#')) return;
-      
+
       // Skip if it has a target attribute (opens in new window/tab)
       if (link.target && link.target !== '_self') return;
-      
+
       // Skip if it's a download link
       if (link.hasAttribute('download')) return;
-      
+
       // Check if modifier keys are pressed (Ctrl, Cmd, Shift, Alt)
       if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
-      
+
       // Check if it's a middle click (open in new tab)
       if (e.button !== 0) return;
-      
+
       debug(`Intercepted link click to: ${href}`);
-      
+
       // Mark as processing to prevent double-handling
       link.dataset.guardProcessing = 'true';
-      
+
       // Get navigation type (default to push)
       const navigateType = link.dataset.replace === 'true' ? 'replace' : 'push';
-      
+
       // Check guards
       const defs = [...guardMapRef.current.values()];
-      const enabledGuards = defs.filter(({ enabled }) => 
+      const enabledGuards = defs.filter(({ enabled }) =>
         enabled({ to: href, type: navigateType })
       );
-      
+
       if (enabledGuards.length === 0) {
         // No guards enabled, allow navigation
         delete link.dataset.guardProcessing;
         debug('No guards enabled, allowing navigation');
         return;
       }
-      
+
       // We have guards to check - prevent default immediately for async handling
       e.preventDefault();
       e.stopPropagation();
       e.stopImmediatePropagation();
-      
+
       let shouldNavigate = true;
-      
+
       for (const { callback } of enabledGuards) {
         debug(`Calling guard callback for ${navigateType} to ${href}`);
-        
+
         try {
           const result = await callback({ to: href, type: navigateType });
           debug(`Guard callback returned: ${result}`);
-          
+
           if (!result) {
             shouldNavigate = false;
             break;
@@ -138,10 +141,10 @@ export function useInterceptLinkClicks({
           break;
         }
       }
-      
+
       // Clean up processing flag
       delete link.dataset.guardProcessing;
-      
+
       if (shouldNavigate) {
         debug('All guards passed, navigating programmatically');
         // Navigate programmatically since we prevented the default
@@ -167,7 +170,7 @@ export function useInterceptLinkClicks({
 
     // Add event listener in capture phase to intercept before React
     document.addEventListener('click', handleLinkClick, true);
-    
+
     // Also observe DOM changes to handle dynamically added links
     const observer = new MutationObserver((mutations) => {
       mutations.forEach((mutation) => {
@@ -182,16 +185,16 @@ export function useInterceptLinkClicks({
         });
       });
     });
-    
+
     observer.observe(document.body, {
       childList: true,
       subtree: true,
     });
-    
+
     return () => {
       debug('Cleaning up link click interceptor');
       document.removeEventListener('click', handleLinkClick, true);
       observer.disconnect();
     };
-  }, [guardMapRef]);
+  }, [guardMapRef, disabled]);
 }

--- a/src/hooks/useInterceptPageUnload.ts
+++ b/src/hooks/useInterceptPageUnload.ts
@@ -1,12 +1,17 @@
+import { MutableRefObject } from "react";
 import { GuardDef } from "../types";
 import { useIsomorphicLayoutEffect } from "./useIsomorphicLayoutEffect";
 
 export function useInterceptPageUnload({
   guardMapRef,
+  disabled,
 }: {
-  guardMapRef: React.MutableRefObject<Map<string, GuardDef>>;
+  guardMapRef: MutableRefObject<Map<string, GuardDef>>;
+  disabled: boolean;
 }) {
   useIsomorphicLayoutEffect(() => {
+    if (disabled) return;
+
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
       for (const def of guardMapRef.current.values()) {
         // We does not support confirm() on beforeunload as
@@ -25,5 +30,5 @@ export function useInterceptPageUnload({
     return () => {
       window.removeEventListener("beforeunload", handleBeforeUnload);
     };
-  }, []);
+  }, [disabled]);
 }

--- a/src/hooks/useInterceptPopState.ts
+++ b/src/hooks/useInterceptPopState.ts
@@ -1,7 +1,8 @@
 import { RouterContext } from "next/dist/shared/lib/router-context.shared-runtime";
-import { useContext } from "react";
+import { MutableRefObject, useContext } from "react";
 import { GuardDef, RenderedState } from "../types";
 import { DEBUG } from "../utils/debug";
+import { evaluateGuards } from "../utils/evaluateGuards";
 import {
   newToken,
   setupHistoryAugmentationOnce,
@@ -16,12 +17,16 @@ const renderedStateRef: { current: RenderedState } = {
 
 export function useInterceptPopState({
   guardMapRef,
+  disabled,
 }: {
-  guardMapRef: React.MutableRefObject<Map<string, GuardDef>>;
+  guardMapRef: MutableRefObject<Map<string, GuardDef>>;
+  disabled: boolean;
 }) {
   const pagesRouter = useContext(RouterContext);
 
   useIsomorphicLayoutEffect(() => {
+    if (disabled) return;
+
     // NOTE: Called before Next.js router setup which is useEffect().
     // https://github.com/vercel/next.js/blob/50b9966ba9377fd07a27e3f80aecd131fa346482/packages/next/src/client/components/app-router.tsx#L518
     const { writeState } = setupHistoryAugmentationOnce({ renderedStateRef });
@@ -50,11 +55,11 @@ export function useInterceptPopState({
         window.removeEventListener("popstate", onPopState);
       };
     }
-  }, [pagesRouter]);
+  }, [pagesRouter, disabled]);
 }
 
 function createHandlePopState(
-  guardMapRef: React.MutableRefObject<Map<string, GuardDef>>,
+  guardMapRef: MutableRefObject<Map<string, GuardDef>>,
   writeState: () => void
 ) {
   let dispatchedState: unknown;
@@ -92,9 +97,7 @@ function createHandlePopState(
 
     const to = location.pathname + location.search;
 
-    const defs = [...guardMapRef.current.values()];
-
-    if (nextState === dispatchedState || defs.length === 0) {
+    if (nextState === dispatchedState || guardMapRef.current.size === 0) {
       if (DEBUG)
         console.log(
           `useInterceptPopState(): Accept popstate event, index: ${nextIndex}`
@@ -109,36 +112,23 @@ function createHandlePopState(
         `useInterceptPopState(): Suspend popstate event, index: ${nextIndex}`
       );
 
-    // Wait for all callbacks to be resolved
+    // Wait for guard evaluation
     (async () => {
-      let i = -1;
+      const ok = await evaluateGuards(guardMapRef, { to, type: "popstate" });
 
-      for (const def of defs) {
-        i++;
-
-        if (!def.enabled({ to, type: "popstate" })) continue;
+      if (!ok) {
         if (DEBUG) {
           console.log(
-            `useInterceptPopState(): confirmation for listener index ${i}`
+            `useInterceptPopState(): Cancel popstate event, go(): ${
+              renderedStateRef.current.index
+            } - ${nextIndex} = ${-delta}`
           );
         }
-
-        const confirm = await def.callback({ to, type: "popstate" });
-        // TODO: check cancel while waiting for navigation guard
-        if (!confirm) {
-          if (DEBUG) {
-            console.log(
-              `useInterceptPopState(): Cancel popstate event, go(): ${
-                renderedStateRef.current.index
-              } - ${nextIndex} = ${-delta}`
-            );
-          }
-          if (delta !== 0) {
-            // discard event
-            window.history.go(-delta);
-          }
-          return;
+        if (delta !== 0) {
+          // discard event
+          window.history.go(-delta);
         }
+        return;
       }
 
       if (DEBUG) {

--- a/src/hooks/useInterceptPopState.ts
+++ b/src/hooks/useInterceptPopState.ts
@@ -1,6 +1,6 @@
 import { RouterContext } from "next/dist/shared/lib/router-context.shared-runtime";
 import { MutableRefObject, useContext } from "react";
-import { GuardDef, RenderedState } from "../types";
+import { GuardDef, NavigationGuardCallback, RenderedState } from "../types";
 import { DEBUG } from "../utils/debug";
 import { evaluateGuards } from "../utils/evaluateGuards";
 import {
@@ -17,9 +17,11 @@ const renderedStateRef: { current: RenderedState } = {
 
 export function useInterceptPopState({
   guardMapRef,
+  mockConfirmRef,
   disabled,
 }: {
   guardMapRef: MutableRefObject<Map<string, GuardDef>>;
+  mockConfirmRef: MutableRefObject<NavigationGuardCallback | undefined>;
   disabled: boolean;
 }) {
   const pagesRouter = useContext(RouterContext);
@@ -31,7 +33,11 @@ export function useInterceptPopState({
     // https://github.com/vercel/next.js/blob/50b9966ba9377fd07a27e3f80aecd131fa346482/packages/next/src/client/components/app-router.tsx#L518
     const { writeState } = setupHistoryAugmentationOnce({ renderedStateRef });
 
-    const handlePopState = createHandlePopState(guardMapRef, writeState);
+    const handlePopState = createHandlePopState(
+      guardMapRef,
+      mockConfirmRef,
+      writeState
+    );
 
     if (pagesRouter) {
       pagesRouter.beforePopState(() => handlePopState(history.state));
@@ -60,6 +66,7 @@ export function useInterceptPopState({
 
 function createHandlePopState(
   guardMapRef: MutableRefObject<Map<string, GuardDef>>,
+  mockConfirmRef: MutableRefObject<NavigationGuardCallback | undefined>,
   writeState: () => void
 ) {
   let dispatchedState: unknown;
@@ -114,7 +121,10 @@ function createHandlePopState(
 
     // Wait for guard evaluation
     (async () => {
-      const ok = await evaluateGuards(guardMapRef, { to, type: "popstate" });
+      const ok = await evaluateGuards(guardMapRef, mockConfirmRef, {
+        to,
+        type: "popstate",
+      });
 
       if (!ok) {
         if (DEBUG) {

--- a/src/hooks/useInterceptedAppRouter.ts
+++ b/src/hooks/useInterceptedAppRouter.ts
@@ -5,6 +5,7 @@ import {
 import { MutableRefObject, useContext, useMemo } from "react";
 import { GuardDef } from "../types";
 import { debug } from "../utils/debug";
+import { evaluateGuards } from "../utils/evaluateGuards";
 
 export function useInterceptedAppRouter({
   guardMapRef,
@@ -25,21 +26,8 @@ export function useInterceptedAppRouter({
       to: string,
       accepted: () => void
     ) => {
-      debug(`Navigation attempt: ${type} to ${to}`);
-      const defs = [...guardMapRef.current.values()];
-      for (const { enabled, callback } of defs) {
-        if (!enabled({ to, type })) continue;
-
-        debug(`Calling guard callback for ${type} to ${to}`);
-        const confirm = await callback({ to, type });
-        debug(`Guard callback returned: ${confirm}`);
-        if (!confirm) {
-          debug(`Navigation blocked`);
-          return;
-        }
-      }
-      debug(`All guards passed, proceeding with navigation`);
-      accepted();
+      const ok = await evaluateGuards(guardMapRef, { to, type });
+      if (ok) accepted();
     };
 
     return {
@@ -55,5 +43,5 @@ export function useInterceptedAppRouter({
         guarded("refresh", location.href, () => origRouter.refresh(...args));
       },
     };
-  }, [origRouter]);
+  }, [origRouter, guardMapRef]);
 }

--- a/src/hooks/useInterceptedAppRouter.ts
+++ b/src/hooks/useInterceptedAppRouter.ts
@@ -3,14 +3,16 @@ import {
   AppRouterInstance,
 } from "next/dist/shared/lib/app-router-context.shared-runtime";
 import { MutableRefObject, useContext, useMemo } from "react";
-import { GuardDef } from "../types";
+import { GuardDef, NavigationGuardCallback } from "../types";
 import { debug } from "../utils/debug";
 import { evaluateGuards } from "../utils/evaluateGuards";
 
 export function useInterceptedAppRouter({
   guardMapRef,
+  mockConfirmRef,
 }: {
   guardMapRef: MutableRefObject<Map<string, GuardDef>>;
+  mockConfirmRef: MutableRefObject<NavigationGuardCallback | undefined>;
 }) {
   const origRouter = useContext(AppRouterContext);
 
@@ -26,7 +28,10 @@ export function useInterceptedAppRouter({
       to: string,
       accepted: () => void
     ) => {
-      const ok = await evaluateGuards(guardMapRef, { to, type });
+      const ok = await evaluateGuards(guardMapRef, mockConfirmRef, {
+        to,
+        type,
+      });
       if (ok) accepted();
     };
 
@@ -43,5 +48,5 @@ export function useInterceptedAppRouter({
         guarded("refresh", location.href, () => origRouter.refresh(...args));
       },
     };
-  }, [origRouter, guardMapRef]);
+  }, [origRouter, guardMapRef, mockConfirmRef]);
 }

--- a/src/hooks/useInterceptedPagesRouter.ts
+++ b/src/hooks/useInterceptedPagesRouter.ts
@@ -2,13 +2,15 @@ import { NextRouter } from "next/dist/client/router";
 import { RouterContext } from "next/dist/shared/lib/router-context.shared-runtime";
 import { Url } from "next/dist/shared/lib/router/router";
 import { MutableRefObject, useContext, useMemo } from "react";
-import { GuardDef } from "../types";
+import { GuardDef, NavigationGuardCallback } from "../types";
 import { evaluateGuards } from "../utils/evaluateGuards";
 
 export function useInterceptedPagesRouter({
   guardMapRef,
+  mockConfirmRef,
 }: {
   guardMapRef: MutableRefObject<Map<string, GuardDef>>;
+  mockConfirmRef: MutableRefObject<NavigationGuardCallback | undefined>;
 }) {
   const origRouter = useContext(RouterContext);
 
@@ -21,7 +23,10 @@ export function useInterceptedPagesRouter({
       accepted: () => Promise<boolean>
     ): Promise<boolean> => {
       const to = typeof toUrl === "string" ? toUrl : toUrl.href ?? "";
-      const ok = await evaluateGuards(guardMapRef, { to, type });
+      const ok = await evaluateGuards(guardMapRef, mockConfirmRef, {
+        to,
+        type,
+      });
       if (!ok) return false;
       return await accepted();
     };
@@ -43,5 +48,5 @@ export function useInterceptedPagesRouter({
         });
       },
     };
-  }, [origRouter, guardMapRef]);
+  }, [origRouter, guardMapRef, mockConfirmRef]);
 }

--- a/src/hooks/useInterceptedPagesRouter.ts
+++ b/src/hooks/useInterceptedPagesRouter.ts
@@ -3,6 +3,7 @@ import { RouterContext } from "next/dist/shared/lib/router-context.shared-runtim
 import { Url } from "next/dist/shared/lib/router/router";
 import { MutableRefObject, useContext, useMemo } from "react";
 import { GuardDef } from "../types";
+import { evaluateGuards } from "../utils/evaluateGuards";
 
 export function useInterceptedPagesRouter({
   guardMapRef,
@@ -20,14 +21,8 @@ export function useInterceptedPagesRouter({
       accepted: () => Promise<boolean>
     ): Promise<boolean> => {
       const to = typeof toUrl === "string" ? toUrl : toUrl.href ?? "";
-      const defs = [...guardMapRef.current.values()];
-      for (const { enabled, callback } of defs) {
-        if (!enabled({ to, type })) continue;
-
-        const confirm = await callback({ to, type });
-        if (!confirm) return false;
-      }
-
+      const ok = await evaluateGuards(guardMapRef, { to, type });
+      if (!ok) return false;
       return await accepted();
     };
 
@@ -48,5 +43,5 @@ export function useInterceptedPagesRouter({
         });
       },
     };
-  }, [origRouter]);
+  }, [origRouter, guardMapRef]);
 }

--- a/src/hooks/useNavigationGuard.ts
+++ b/src/hooks/useNavigationGuard.ts
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useId, useRef, useState } from "react";
+import { useCallback, useContext, useId, useState } from "react";
 import { NavigationGuardProviderContext } from "../components/NavigationGuardProviderContext";
 import { NavigationGuardCallback, NavigationGuardOptions } from "../types";
 import { useIsomorphicLayoutEffect } from "./useIsomorphicLayoutEffect";
@@ -8,7 +8,7 @@ import { debug } from "../utils/debug";
 export function useNavigationGuard(options: NavigationGuardOptions) {
   const callbackId = useId();
   const guardMapRef = useContext(NavigationGuardProviderContext);
-  if (!guardMapRef && !options.disableForTesting)
+  if (!guardMapRef)
     throw new Error(
       "useNavigationGuard must be used within a NavigationGuardProvider"
     );
@@ -18,8 +18,6 @@ export function useNavigationGuard(options: NavigationGuardOptions) {
   } | null>(null);
 
   useIsomorphicLayoutEffect(() => {
-    if (options.disableForTesting) return;
-
     const callback: NavigationGuardCallback = (params) => {
       debug(`Guard callback called with:`, params);
       if (options.confirm) {
@@ -38,17 +36,15 @@ export function useNavigationGuard(options: NavigationGuardOptions) {
 
     const enabled = options.enabled;
 
-    guardMapRef!.current.set(callbackId, {
+    guardMapRef.current.set(callbackId, {
       enabled: typeof enabled === "function" ? enabled : () => enabled ?? true,
       callback,
     });
 
     return () => {
-      guardMapRef!.current.delete(callbackId);
+      guardMapRef.current.delete(callbackId);
     };
-  }, [callbackId, guardMapRef, options.confirm, options.enabled, options.disableForTesting]);
-
-  const active = options.disableForTesting ? false : pendingState !== null;
+  }, [callbackId, guardMapRef, options.confirm, options.enabled]);
 
   const accept = useCallback(() => {
     if (!pendingState) return;
@@ -62,5 +58,5 @@ export function useNavigationGuard(options: NavigationGuardOptions) {
     setPendingState(null);
   }, [pendingState]);
 
-  return { active, accept, reject };
+  return { active: pendingState !== null, accept, reject };
 }

--- a/src/hooks/useNavigationGuard.ts
+++ b/src/hooks/useNavigationGuard.ts
@@ -7,11 +7,12 @@ import { debug } from "../utils/debug";
 // Should memoize callback func
 export function useNavigationGuard(options: NavigationGuardOptions) {
   const callbackId = useId();
-  const guardMapRef = useContext(NavigationGuardProviderContext);
-  if (!guardMapRef)
+  const ctx = useContext(NavigationGuardProviderContext);
+  if (!ctx)
     throw new Error(
       "useNavigationGuard must be used within a NavigationGuardProvider"
     );
+  const { guardMapRef } = ctx;
 
   const [pendingState, setPendingState] = useState<{
     resolve: (accepted: boolean) => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,27 +5,31 @@ export interface NavigationGuardOptions {
 }
 
 /**
- * When set on `NavigationGuardProvider`, the library does not touch any host
- * environment for navigation interception. Intended for unit tests and
- * storybook where mocking `window`/`history`/Next.js internals is undesired.
+ * When set on `NavigationGuardProvider`, the library skips its host-environment
+ * hooks. Intended for unit tests and storybook where touching real `window` /
+ * `history` / `document` is undesired.
  *
- * What it disables (library-side hooks into the environment):
- * - registering `popstate`, `beforeunload`, and capture-phase `click` listeners
- * - augmenting `window.history` (token / stack-index injection)
- * - overriding Next.js App Router and Pages Router contexts
+ * What it disables (host-environment side):
+ * - `popstate`, `beforeunload`, and capture-phase `click` listeners
+ * - `window.history` augmentation (token / stack-index injection)
  * - the click-link interceptor that ships for Next.js 15.3+
  *
  * What it intentionally leaves alone (user component contract):
  * - the `enabled` predicate passed to `useNavigationGuard`
  * - the `confirm` callback
  * - the `active` / `accept` / `reject` state used by custom confirmation UIs
+ * - the App Router / Pages Router `RouterContext` overrides — navigation
+ *   driven through Next.js routers (including mock routers in tests) still
+ *   evaluates registered guards
  *
- * In other words: `useNavigationGuard` keeps registering and behaving as a
- * normal hook; only the library's bridge to the real navigation events is
- * inert. Tests that need to drive guard evaluation should do so through the
- * user component's own surface (e.g. mock `confirm` and assert on `active`).
+ * Two forms:
+ * - `true`: each guard's own `confirm` runs as in production.
+ * - `{ mockConfirm }`: the supplied callback replaces every guard's `confirm`
+ *   during evaluation, so tests can drive accept/reject deterministically
+ *   (e.g. `jest.fn().mockResolvedValue(true)`) without rendering the
+ *   confirmation UI. Per-guard `enabled` predicates are still evaluated.
  */
-export type DisableForTesting = boolean;
+export type DisableForTesting = boolean | { mockConfirm: NavigationGuardCallback };
 
 export interface NavigationGuardParams {
   to: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,14 +2,30 @@ export interface NavigationGuardOptions {
   /** @default true */
   enabled?: boolean | ((params: NavigationGuardParams) => boolean);
   confirm?: NavigationGuardCallback;
-  /**
-   * When true, the hook becomes a complete no-op: no guard is registered,
-   * NavigationGuardProvider context is not required, and `active` is always false.
-   * Intended for test and storybook environments.
-   * @default false
-   */
-  disableForTesting?: boolean;
 }
+
+/**
+ * When set on `NavigationGuardProvider`, the library does not touch any host
+ * environment for navigation interception. Intended for unit tests and
+ * storybook where mocking `window`/`history`/Next.js internals is undesired.
+ *
+ * What it disables (library-side hooks into the environment):
+ * - registering `popstate`, `beforeunload`, and capture-phase `click` listeners
+ * - augmenting `window.history` (token / stack-index injection)
+ * - overriding Next.js App Router and Pages Router contexts
+ * - the click-link interceptor that ships for Next.js 15.3+
+ *
+ * What it intentionally leaves alone (user component contract):
+ * - the `enabled` predicate passed to `useNavigationGuard`
+ * - the `confirm` callback
+ * - the `active` / `accept` / `reject` state used by custom confirmation UIs
+ *
+ * In other words: `useNavigationGuard` keeps registering and behaving as a
+ * normal hook; only the library's bridge to the real navigation events is
+ * inert. Tests that need to drive guard evaluation should do so through the
+ * user component's own surface (e.g. mock `confirm` and assert on `active`).
+ */
+export type DisableForTesting = boolean;
 
 export interface NavigationGuardParams {
   to: string;

--- a/src/utils/evaluateGuards.ts
+++ b/src/utils/evaluateGuards.ts
@@ -15,14 +15,20 @@ export async function evaluateGuards(
 
   const mockConfirm = mockConfirmRef.current;
 
+  let i = -1;
   for (const { enabled, callback } of guardMapRef.current.values()) {
+    i++;
     if (!enabled(params)) continue;
 
     const confirmFn = mockConfirm ?? callback;
     if (mockConfirm) {
-      debug(`Calling mockConfirm for ${params.type} to ${params.to}`);
+      debug(
+        `Calling mockConfirm for ${params.type} to ${params.to} (listener index ${i})`
+      );
     } else {
-      debug(`Calling guard callback for ${params.type} to ${params.to}`);
+      debug(
+        `Calling guard callback for ${params.type} to ${params.to} (listener index ${i})`
+      );
     }
     const confirm = await confirmFn(params);
     debug(`Guard callback returned: ${confirm}`);

--- a/src/utils/evaluateGuards.ts
+++ b/src/utils/evaluateGuards.ts
@@ -1,19 +1,28 @@
 import { MutableRefObject } from "react";
-import { GuardDef, NavigationGuardParams } from "../types";
+import {
+  GuardDef,
+  NavigationGuardCallback,
+  NavigationGuardParams,
+} from "../types";
 import { debug } from "./debug";
 
 export async function evaluateGuards(
   guardMapRef: MutableRefObject<Map<string, GuardDef>>,
+  mockConfirmRef: MutableRefObject<NavigationGuardCallback | undefined>,
   params: NavigationGuardParams
 ): Promise<boolean> {
   debug(`Navigation attempt: ${params.type} to ${params.to}`);
 
+  const mockConfirm = mockConfirmRef.current;
+
   for (const { enabled, callback } of guardMapRef.current.values()) {
     if (!enabled(params)) continue;
 
-    debug(`Calling guard callback`);
-    const confirm = await callback(params);
-    debug(`Guard callback returned: ${confirm}`);
+    const confirmFn = mockConfirm ?? callback;
+    if (mockConfirm) debug(`Calling mockConfirm`);
+    else debug(`Calling guard callback`);
+    const confirm = await confirmFn(params);
+    debug(`Confirm returned: ${confirm}`);
     if (!confirm) {
       debug(`Navigation blocked`);
       return false;

--- a/src/utils/evaluateGuards.ts
+++ b/src/utils/evaluateGuards.ts
@@ -1,0 +1,25 @@
+import { MutableRefObject } from "react";
+import { GuardDef, NavigationGuardParams } from "../types";
+import { debug } from "./debug";
+
+export async function evaluateGuards(
+  guardMapRef: MutableRefObject<Map<string, GuardDef>>,
+  params: NavigationGuardParams
+): Promise<boolean> {
+  debug(`Navigation attempt: ${params.type} to ${params.to}`);
+
+  for (const { enabled, callback } of guardMapRef.current.values()) {
+    if (!enabled(params)) continue;
+
+    debug(`Calling guard callback`);
+    const confirm = await callback(params);
+    debug(`Guard callback returned: ${confirm}`);
+    if (!confirm) {
+      debug(`Navigation blocked`);
+      return false;
+    }
+  }
+
+  debug(`All guards passed`);
+  return true;
+}

--- a/src/utils/evaluateGuards.ts
+++ b/src/utils/evaluateGuards.ts
@@ -19,16 +19,19 @@ export async function evaluateGuards(
     if (!enabled(params)) continue;
 
     const confirmFn = mockConfirm ?? callback;
-    if (mockConfirm) debug(`Calling mockConfirm`);
-    else debug(`Calling guard callback`);
+    if (mockConfirm) {
+      debug(`Calling mockConfirm for ${params.type} to ${params.to}`);
+    } else {
+      debug(`Calling guard callback for ${params.type} to ${params.to}`);
+    }
     const confirm = await confirmFn(params);
-    debug(`Confirm returned: ${confirm}`);
+    debug(`Guard callback returned: ${confirm}`);
     if (!confirm) {
       debug(`Navigation blocked`);
       return false;
     }
   }
 
-  debug(`All guards passed`);
+  debug(`All guards passed, proceeding with navigation`);
   return true;
 }


### PR DESCRIPTION
## Summary

Reshapes `disableForTesting` (introduced but never released as 0.3.0) from a per-hook `boolean` option into a `NavigationGuardProvider` prop with a richer contract.

`disableForTesting` is now `boolean | { mockConfirm }`:

- `true` — library skips its host-environment hooks (no `popstate` / `beforeunload` / capture-phase `click` listeners, no `window.history` augmentation, no Next.js 15.3+ link-click interceptor). The App Router / Pages Router context overrides remain in place, so navigation through Next.js routers (incl. mock routers in tests) still evaluates registered guards with the user's real `confirm`.
- `{ mockConfirm }` — same as above, plus replaces every registered guard's `confirm` during evaluation. Per-guard `enabled` predicates still run. Useful for asserting on navigation attempts in tests without rendering the confirmation UI.

The hook-side `disableForTesting` option (committed as part of the unshipped 0.3.0 in `e65773a`) is removed; `useNavigationGuard` once again throws if there is no provider.

Also extracts a shared `evaluateGuards` util used by `useInterceptedAppRouter`, `useInterceptedPagesRouter`, and `useInterceptPopState`.

## Release prep folded in

Since 0.3.0 was bumped in `package.json` / CHANGELOG but never tagged or published to npm, this PR also tidies up the 0.3.0 release notes:

- bump `next` devDependency to `^14.2.35` (latest 14.2.x patch)
- redate `[0.3.0]` to today
- add Fixed entries for #48 (null `history.state` in `createHandlePopState`) and #38 (import types) which landed since v0.2.0 but were not in the changelog
- record the Next.js 16.2 E2E CI addition (`f24ecd2`)

## Test plan

- [x] `pnpm run build` (tsc) — clean
- [x] `pnpm run check:packaging` — all four resolution modes 🟢
- [ ] `pnpm e2e` against the matrix — please run in CI (this branch does not yet add automated tests for the `mockConfirm` shape; manual sanity check recommended in App Router and Pages Router examples)
- [ ] Verify a downstream test using `disableForTesting` (boolean) renders without touching `window.history`
- [ ] Verify `disableForTesting={{ mockConfirm }}` causes navigation through a mocked Next.js router to call `mockConfirm` with the right `params`

🤖 Generated with [Claude Code](https://claude.com/claude-code)